### PR TITLE
Update docs for package-style usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,27 @@ pip install -e .
 
 In a Jupyter Notebook:
 
+First install the project in editable mode so the `src` package is available:
+
+```bash
+pip install -e .
+```
+
+Run the backtest from the command line:
+
+```bash
+python -m src.run_backtest
+```
+
+Or programmatically:
+
 ```python
-import sys
-sys.path.append("src")
-from run_backtest import main
-main(config=...)
+import src.config as config
+import src.run_backtest as run_backtest
+
+# override configuration options here
+config.BACKTEST_START_DATE = ...
+run_backtest.main()
 ```
 
 Command-line entry points may be added later to run the momentum backtest directly from the shell.

--- a/docs/UsingJupyter.md
+++ b/docs/UsingJupyter.md
@@ -20,7 +20,7 @@ conda activate momentum46
 
 ## 3. Install dependencies
 
-Install the packages required by the project and the notebook interface. Optionally install the project itself in editable mode so modules can be imported from `src`.
+Install the packages required by the project and the notebook interface. The project should be installed in editable mode so the `src` package can be imported without manually editing `sys.path`.
 
 ```bash
 pip install -r requirements.txt
@@ -36,4 +36,4 @@ Start Jupyter and open the example notebook in the `examples/` folder:
 jupyter notebook
 ```
 
-In the browser that appears, open `examples/RunBacktest.ipynb`. Edit the paths in the first code cell so they point to your local CSV price data. Execute each cell in turn to run the backtest and view the resulting summary tables.
+In the browser that appears, open `examples/RunBacktest.ipynb`. The first code cell imports `src.config` and defines the CSV paths—update those variables to point to your local data. Then run the remaining cells to execute the backtest and view the resulting summary tables.  No manual `sys.path` modification is required.


### PR DESCRIPTION
## Summary
- update README usage instructions to install the project and run modules from the `src` package
- clarify Jupyter notebook setup steps
- remove manual `sys.path` edits from example notebook

## Testing
- `pip install -r requirements-test.txt`
- `pip install -e .`
- `pip install ipython matplotlib`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687773cfc0a0832e84c3c1015c87a24c